### PR TITLE
Increase run timeout

### DIFF
--- a/.github/workflows/reusable_e2e_test_run.yml
+++ b/.github/workflows/reusable_e2e_test_run.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
-        timeout-minutes: 50
+        timeout-minutes: 60
         with:
           browser: ${{ inputs.browser }}
           spec: ${{ inputs.suite == 'all' && 'cypress/**' || format('cypress/e2e/{0}/*.cy.js', inputs.suite == 'superadmin' && 'super-admin' || inputs.suite) }}


### PR DESCRIPTION
Our tests now take just about 40 min to finish. This change ensures they don't timeout