### PR TITLE
fix checking, after the org type gets changed to Individual

### DIFF
--- a/cypress/e2e/applicant/applicant-v2-empty-filled-org-submit-application.cy.js
+++ b/cypress/e2e/applicant/applicant-v2-empty-filled-org-submit-application.cy.js
@@ -75,7 +75,7 @@ describe("Apply for a Grant V2", () => {
     log("Apply V2 Internal MQ Empty - Filling out MQ as Non-Limited Company");
     validateMqNonLimitedJourney();
 
-    // Go back to Org Type, change to Individual and check that Companies House and Charity Commission are skipped and that copy is changed
+    // Go back to Org Type, change to Individual (this will set the CCN and CHN to null) and check that Companies House and Charity Commission are skipped and that copy is changed
     log("Apply V2 Internal MQ Empty - Filling out MQ as Individual");
     validateMqIndividualJourney();
 
@@ -102,7 +102,8 @@ describe("Apply for a Grant V2", () => {
     validateMqLimitedCompanySummaryScreen();
 
     cy.contains("Confirm your details");
-    confirmDetailsOnSummaryScreen(MQ_DETAILS);
+    // because previously we selected Individual, CHN and CCN are null so it will show the -
+    confirmDetailsOnSummaryScreen(MQ_DETAILS, true);
 
     // Click through and edit fields
     log("Apply V2 Internal MQ Empty - Editing details from summary screen");
@@ -146,6 +147,7 @@ describe("Apply for a Grant V2", () => {
     log(
       "Apply V2 Internal MQ Empty - Validating MQ summary screen for Charity",
     );
+    // because previously we selected Individual, CHN and CCN are null so it will show the -
     validateOrgDetailsForCharity();
 
     // Confirm Org & Funding Details and Submit
@@ -154,6 +156,7 @@ describe("Apply for a Grant V2", () => {
       "Charity",
       ["North East (England)"],
       MQ_DETAILS,
+      true,
     );
 
     log("Apply V2 Internal MQ Empty - Reviewing submission");

--- a/cypress/e2e/applicant/helper.js
+++ b/cypress/e2e/applicant/helper.js
@@ -410,6 +410,7 @@ export const editDetailsOnSummaryScreen = (details) => {
     "IAmApplyingAsAnIndividual",
     "LimitedCompany",
     "NonLimitedCompany",
+    "LocalAuthority",
     "Charity",
   ].forEach((item) => {
     cy.get(`[data-cy=cy-radioInput-option-${item}]`)
@@ -429,7 +430,7 @@ export const editDetailsOnSummaryScreen = (details) => {
 
   cy.contains("Enter your Companies House number (if you have one)");
   cy.get("[data-cy=cy-companiesHouseNumber-text-input]")
-    .should("have.value", details.companiesHouse)
+    .should("have.value", "")
     .clear()
     .type(details.companiesHouse + "1");
   clickSaveAndContinue();
@@ -445,7 +446,7 @@ export const editDetailsOnSummaryScreen = (details) => {
 
   cy.contains("Enter your Charity Commission number (if you have one)");
   cy.get("[data-cy=cy-charityCommissionNumber-text-input]")
-    .should("have.value", details.charitiesCommission)
+    .should("have.value", "")
     .clear()
     .type(details.charitiesCommission + "1");
   clickSaveAndContinue();
@@ -644,7 +645,10 @@ export const editFundingDetails = (details) => {
   clickSaveAndContinue();
 };
 
-export const confirmDetailsOnSummaryScreen = (details) => {
+export const confirmDetailsOnSummaryScreen = (
+  details,
+  areCharityCommissionAndCompaniesHouseNumberEmpty = false,
+) => {
   // Confirm your details
 
   // Name
@@ -668,13 +672,19 @@ export const confirmDetailsOnSummaryScreen = (details) => {
 
   // Companies House
   cy.get('[data-cy="cy-organisation-value-Companies House number"]').contains(
-    details.companiesHouse,
+    areCharityCommissionAndCompaniesHouseNumberEmpty
+      ? "-"
+      : details.companiesHouse,
   );
 
   // Charities Commission
   cy.get(
     '[data-cy="cy-organisation-value-Charity Commission number"]',
-  ).contains(details.charitiesCommission);
+  ).contains(
+    areCharityCommissionAndCompaniesHouseNumberEmpty
+      ? "-"
+      : details.charitiesCommission,
+  );
 
   // How much funding
   cy.get(
@@ -750,6 +760,7 @@ export const confirmOrgAndFundingDetails = (
   orgType,
   fundingLocations,
   details,
+  areCharityCommissionAndCompaniesHouseNumberEmpty = false,
 ) => {
   // Check Org Details Match
   cy.get('[data-cy="cy-section-title-link-Your organisation"]').click();
@@ -770,10 +781,18 @@ export const confirmOrgAndFundingDetails = (
       );
     });
   cy.get(
-    `[data-cy="cy-section-value-${details.companiesHouse + suffix}"]`,
+    `[data-cy="cy-section-value-${
+      areCharityCommissionAndCompaniesHouseNumberEmpty
+        ? "null"
+        : details.companiesHouse + suffix
+    }"]`,
   ).should("exist");
   cy.get(
-    `[data-cy="cy-section-value-${details.charitiesCommission + suffix}"]`,
+    `[data-cy="cy-section-value-${
+      areCharityCommissionAndCompaniesHouseNumberEmpty
+        ? "null"
+        : details.charitiesCommission + suffix
+    }"]`,
   ).should("exist");
 
   cy.get('[data-cy="cy-isComplete-question-title"]').contains(


### PR DESCRIPTION
when an applicant changes the Org type to Individual or Local authority or Other, we now set the Companies House Number  and Charity Commission Number values in the mandatory question table as null.

so I updated the test to reflect that.

If the user has previously chosen Limited company, and added CHN and CCN, and then they edit and select the Individual org type, they gonna lose the CHN and CCN.
