### PR TITLE
GAP-2481: Fix flaky find search tests

### DIFF
--- a/cypress/e2e/find/find-search.cy.js
+++ b/cypress/e2e/find/find-search.cy.js
@@ -3,6 +3,7 @@ import { clickThroughPagination, countNumberOfPages } from "./helper";
 
 describe("Find a Grant - Search", () => {
   beforeEach(() => {
+    cy.task("publishGrantsToContentful");
     signInToIntegrationSite();
   });
 


### PR DESCRIPTION
Data set up was entirely dependent on another test being ran and succeeding - this amends that to setup the appropriate data