### PR TITLE
GAP-2481:  Fix flaky find filters spec

### DIFF
--- a/cypress/e2e/find/find-filters.cy.js
+++ b/cypress/e2e/find/find-filters.cy.js
@@ -2,9 +2,6 @@ import { signInToIntegrationSite, log } from "../../common/common";
 
 describe("Filter search results", () => {
   beforeEach(() => {
-    cy.task("setUpUser");
-    cy.task("setUpApplyData");
-    cy.task("setUpFindData");
     cy.task("publishGrantsToContentful");
     signInToIntegrationSite();
   });


### PR DESCRIPTION
Find filters spec also depended on another tests data - amending so we init this data in before each. Removed unneccessary tasks for this test as it shouldn't need any of it