### PR TITLE
GAP-2481: Fix admin navigation promotion spec

### DIFF
--- a/cypress/e2e/admin/admin-navigation-promotion.cy.js
+++ b/cypress/e2e/admin/admin-navigation-promotion.cy.js
@@ -1,5 +1,6 @@
 import {
   clickText,
+  selectActionForItemInTable,
   signInAsApplyApplicant,
   signInAsSuperAdmin,
   signInToIntegrationSite,
@@ -19,15 +20,18 @@ describe("Admin navigation", () => {
     cy.log("Promoting applicant account -> admin account");
     cy.get("[name=searchTerm]").type(Cypress.env("oneLoginApplicantEmail"));
     cy.get("[data-cy=cy-button-Search]").click();
-    cy.get(
-      '[data-cy="cy_table_row-for-Actions-row-0-cell-3"] > .govuk-link',
-    ).click();
-    clickText("Change");
+    selectActionForItemInTable(Cypress.env("oneLoginApplicantEmail"), "Edit", {
+      actionCellElement: "td",
+      textCellElement: "td",
+    });
+    selectActionForItemInTable("Roles", "Change", {
+      actionCellElement: "dd",
+      textCellElement: "dt",
+    });
     cy.get("[data-cy=cy-checkbox-value-3]").check();
     cy.log("Changing user roles");
     clickText("Change Roles");
     cy.log("Adding a department");
-    cy.contains("Change").first().click();
     clickText("Cypress - Test Department");
     clickText("Change department");
     signOut();


### PR DESCRIPTION
Fixing promoting an applicant to an admin test:
- Bad selectors didn't necessarily promote correct user
- Bad selector didn't necessarily grab correct change link (either change roles or departments)
- When promoting an applicant we now navigate directly to the change department page, test needed updating to match that behaviour