### PR TITLE
GAP-2481: Force visit url after signout/signin

### DIFF
--- a/cypress/e2e/admin/admin-due-diligence-v1-internal.cy.js
+++ b/cypress/e2e/admin/admin-due-diligence-v1-internal.cy.js
@@ -74,6 +74,7 @@ describe("Downloads and Due Diligence", () => {
     log("Admin V1 Internal - Download Submission Export - signing in as admin");
     cy.get("[data-cy=cySignInAndApply-Link]").click();
     signInAsAdmin();
+    cy.visit("/apply/admin/dashboard");
 
     // View V1 internal grant
     log("Admin V1 Internal - Download Submission Export - viewing grant");

--- a/cypress/e2e/admin/admin-navigation-promotion.cy.js
+++ b/cypress/e2e/admin/admin-navigation-promotion.cy.js
@@ -40,6 +40,7 @@ describe("Admin navigation", () => {
     );
     cy.get("[data-cy=cySignInAndApply-Link]").click();
     signInAsApplyApplicant();
+    cy.visit("/apply/admin/dashboard");
     cy.log("asserting on content within the admin dashboard");
     cy.contains("Manage a grant");
     cy.contains(

--- a/cypress/e2e/applicant/applicant-v1-submit-internal-application.cy.js
+++ b/cypress/e2e/applicant/applicant-v1-submit-internal-application.cy.js
@@ -60,6 +60,7 @@ describe("Apply for a Grant", () => {
     log("Apply V1 Internal Grant - Signing back in as applicant");
     cy.get("[data-cy=cySignInAndApply-Link]").click();
     signInAsApplyApplicant();
+    cy.visit("/apply/applicant/dashboard");
 
     log("Apply V1 Internal Grant - Returning to in progress application");
     cy.get('[data-cy="cy-your-applications-link"]').click();

--- a/cypress/e2e/superadmin/superadmin-manage-roles.cy.js
+++ b/cypress/e2e/superadmin/superadmin-manage-roles.cy.js
@@ -57,6 +57,7 @@ describe("Super Admin", () => {
     log("Super Admin Manage Roles - Signing in as applicant");
     cy.get('[data-cy="cySignInAndApply-Link"]').click();
     signInAsApplyApplicant();
+    cy.visit("/apply/admin/super-admin-dashboard");
 
     log("Super Admin Manage Roles - Expecting to land on super admin dashbard");
     cy.contains("Manage users");


### PR DESCRIPTION
Singing out then singing in again seems to cause a flakiness issue where you sign in, but aren't taken to the relevant dashboard page.

Amended anywhere that does this to hopefully force visit the correct url